### PR TITLE
secure outputs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ $ curl -X GET "http://localhost:8050/api/v1/operator/list" -H "accept: applicati
      ALLOWED_PROVIDERS = Json array with allowed providers that can access the endpoints
      OPERATOR_ADDRESS = Address used by Compute enviroment (IMPORTANT: Corresponding private key must be set in operator-engine env)
      DEFAULT_NAMESPACE = namespace which will run the jobs
+     X-API-KEY = if defined, when downloading a compute output, will add X-API-KEY header (used for IPFS auth)
+     CLIENT-ID = if defined, when downloading a compute output, will add CLIENT-ID header (used for IPFS auth)
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ $ curl -X GET "http://localhost:8050/api/v1/operator/list" -H "accept: applicati
 ### ENV Vars
 
      ALGO_POD_TIMEOUT  = the maximum amount of time in seconds that an algorithm can use before it is killed
+     STORAGE_EXPIRY = the maximum amount of time in seconds to store the job files outputs
      POSTGRES_DB = Postgres database
      POSTGRES_USER = Postgresql user
      POSTGRES_PASSWORD = Postgresql password

--- a/kubernetes/expose_service.yaml
+++ b/kubernetes/expose_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: operator-api-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: operator-api
+  ports:
+      # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
+    - port: 8050
+      targetPort: 8050
+      # Optional field
+      # By default and for convenience, the Kubernetes control plane will allocate a port from a range (default: 30000-32767)
+      nodePort: 31000

--- a/operator_service/data_store.py
+++ b/operator_service/data_store.py
@@ -52,9 +52,7 @@ def get_sql_status(agreement_id, job_id, owner):
         if row[10] and len(str(row[10])) > 2:
             # need to filter url from object
             outputs = json.loads(str(row[10]))
-            logger.error(f'Output este TODO {outputs}')
             for i, entry in enumerate(outputs):
-                logger.error(f'{i},{entry}')
                 if outputs[i] and "url" in outputs[i]:
                     del outputs[i]['url']
             temprow['results'] = outputs

--- a/operator_service/data_store.py
+++ b/operator_service/data_store.py
@@ -52,8 +52,11 @@ def get_sql_status(agreement_id, job_id, owner):
         if row[10] and len(str(row[10])) > 2:
             # need to filter url from object
             outputs = json.loads(str(row[10]))
+            logger.error(f'Output este TODO {outputs}')
             for i, entry in enumerate(outputs):
-                del outputs[i]['url']
+                logger.error(f'{i},{entry}')
+                if outputs[i] and outputs[i]['url']:
+                    del outputs[i]['url']
             temprow['results'] = outputs
         # temprow['resultsDid'] = ''
         #if row[11] and len(str(row[11])) > 2:
@@ -87,9 +90,12 @@ def get_sql_job_urls(job_id):
     rows = _execute_query(select_query, params, 'get_sql_job_urls', get_rows=True)
     if not rows or len(rows)<1:
         return None, None
-    result = json.loads(str(rows[0][1]))
-    owner = rows[0][0]
-    return result, owner
+    try:
+        result = json.loads(str(rows[0][1]))
+        owner = rows[0][0]
+        return result, owner
+    except:
+        return None, None
 
 def get_sql_jobs(agreement_id, job_id, owner):
     params = dict()

--- a/operator_service/data_store.py
+++ b/operator_service/data_store.py
@@ -55,7 +55,7 @@ def get_sql_status(agreement_id, job_id, owner):
             logger.error(f'Output este TODO {outputs}')
             for i, entry in enumerate(outputs):
                 logger.error(f'{i},{entry}')
-                if outputs[i] and outputs[i]['url']:
+                if outputs[i] and "url" in outputs[i]:
                     del outputs[i]['url']
             temprow['results'] = outputs
         # temprow['resultsDid'] = ''

--- a/operator_service/data_store.py
+++ b/operator_service/data_store.py
@@ -4,11 +4,12 @@ import logging
 import psycopg2
 import simplejson as json
 
+logging.basicConfig(format='%(asctime)s %(message)s')
+logger = logging.getLogger('operator-service')
+logger.setLevel(logging.DEBUG)
 
 def get_sql_status(agreement_id, job_id, owner):
     # enforce strings
-    logging.debug("Start get_sql_status\n")
-    logging.debug("Connected\n")
     params = dict()
     select_query = '''
     SELECT agreementId, workflowId, owner, status, statusText, 
@@ -30,9 +31,6 @@ def get_sql_status(agreement_id, job_id, owner):
         select_query = select_query + " AND owner=%(owner)s"
         params['owner'] = str(owner)
 
-    logging.debug(f'Got select_query: {select_query}')
-    logging.debug(f'Got params: {params}')
-
     result = []
     rows = _execute_query(select_query, params, 'get_sql_status', get_rows=True)
     if not rows:
@@ -49,14 +47,18 @@ def get_sql_status(agreement_id, job_id, owner):
         temprow['dateFinished'] = row[6]
         # temprow['configlogUrl']=row[7]
         # temprow['publishlogUrl']=row[8]
-        temprow['algorithmLogUrl'] = row[9]
-        temprow['resultsUrl'] = ''
+        # temprow['algorithmLogUrl'] = row[9]
+        temprow['results'] = ''
         if row[10] and len(str(row[10])) > 2:
-            temprow['resultsUrl'] = json.loads(str(row[10]))
-        temprow['resultsDid'] = ''
-        if row[11] and len(str(row[11])) > 2:
-            ddo_json = json.loads(str(row[11]))
-            temprow['resultsDid'] = ddo_json.get('id', '')
+            # need to filter url from object
+            outputs = json.loads(str(row[10]))
+            for i, entry in enumerate(outputs):
+                del outputs[i]['url']
+            temprow['results'] = outputs
+        # temprow['resultsDid'] = ''
+        #if row[11] and len(str(row[11])) > 2:
+        #    ddo_json = json.loads(str(row[11]))
+        #    temprow['resultsDid'] = ddo_json.get('id', '')
         temprow['stopreq'] = row[12]
         temprow['removed'] = row[13]
         workflow_dict=json.loads(row[14])
@@ -72,10 +74,24 @@ def get_sql_status(agreement_id, job_id, owner):
         result.append(temprow)
     return result
 
+def get_sql_job_urls(job_id):
+    # get outputsURL & job owner as a tuple
+    params = dict()
+    select_query = '''
+    SELECT owner, outputsURL FROM jobs WHERE workflowId=%(jobId)s
+    '''
+    if job_id is None:
+        return None, None
+
+    params['jobId'] = str(job_id)
+    rows = _execute_query(select_query, params, 'get_sql_job_urls', get_rows=True)
+    if not rows or len(rows)<1:
+        return None, None
+    result = json.loads(str(rows[0][1]))
+    owner = rows[0][0]
+    return result, owner
 
 def get_sql_jobs(agreement_id, job_id, owner):
-    logging.debug("Start get_sql_status\n")
-    logging.debug("Connected\n")
     params = dict()
     select_query = "SELECT workflowId FROM jobs WHERE 1=1"
     if agreement_id is not None:
@@ -87,15 +103,13 @@ def get_sql_jobs(agreement_id, job_id, owner):
     if owner is not None:
         select_query = select_query + " AND owner=%(owner)s"
         params['owner'] = str(owner)
-    logging.debug(f'Got select_query: {select_query}')
-    logging.debug(f'Got params: {params}')
     try:
         rows = _execute_query(select_query, params, 'get_sql_jobs', get_rows=True)
         if not rows:
             return []
         return [row[0] for row in rows]
     except (Exception, psycopg2.Error) as error:
-        logging.error(f'PG query error: {error}')
+        logger.error(f'PG query error: {error}')
         return
 
 def get_sql_running_jobs():
@@ -169,7 +183,7 @@ def get_pg_connection_and_cursor():
         cursor = connection.cursor()
         return connection, cursor
     except (Exception, psycopg2.Error) as error:
-        logging.error(f'New PG connect error: {error}')
+        logger.error(f'New PG connect error: {error}')
         return None, None
 
 
@@ -191,7 +205,7 @@ def _execute_query(query, record, msg, get_rows=False):
             connection.commit()
 
     except (Exception, psycopg2.Error) as error:
-        logging.error(f'Got PG error in {msg}: {error}')
+        logger.error(f'Got PG error in {msg}: {error}')
     finally:
         # closing database connection.
         if connection:

--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -382,11 +382,17 @@ def get_indexed_result():
         in: query
         description: consumerSignature
         type: string
+      - name: signatureText
+        in: query
+        description: signatureText
+        type: string
     responses:
       200:
         description: File content
       400:
         description: Error
+      404:
+        description: Not found
     """
     try:
         requests_session = get_requests_session()

--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -169,6 +169,7 @@ def start_compute_job():
         # get resources
         astage['compute']['resources'] = compute_resources_def
         astage['compute']['namespace'] = namespaces_def['namespace']
+        astage['compute']['storageExpiry'] = int(os.getenv("STORAGE_EXPIRY", 0))
 
     job_id = generate_new_id()
     logger.debug(f'Got job_id: {job_id}')

--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -370,7 +370,7 @@ def get_indexed_result():
         in: query
         description: output index
         type: number
-      - name: job_id
+      - name: jobId
         in: query
         description: Id of the job.
         type: string
@@ -382,9 +382,9 @@ def get_indexed_result():
         in: query
         description: consumerSignature
         type: string
-      - name: signatureText
+      - name: consumerAddress
         in: query
-        description: signatureText
+        description: consumerAddress
         type: string
     responses:
       200:
@@ -398,7 +398,7 @@ def get_indexed_result():
         requests_session = get_requests_session()
         data = request.args if request.args else request.json
         index = int(data.get('index'))
-        job_id = data.get('job_id')
+        job_id = data.get('jobId')
         if index is None and job_id is None:
           msg = f'Both index & job_id are requred'
           return jsonify(error=msg), 400

--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -406,10 +406,11 @@ def get_indexed_result():
         # TO DO - check owner here
         logger.info(f"Got {owner}")
         logger.info(f"Got {outputs}")
-        if outputs is None:
+        if outputs is None or not isinstance(outputs, list):
           msg = f'No results for job {job_id}'
           return jsonify(error=msg), 404
         # check the index
+        logger.info(f"Len outputs {len(outputs)}, index: {index}")
         if index >= len(outputs):
           msg = f'No such index {index} in this compute job'
           return jsonify(error=msg), 404

--- a/operator_service/run.py
+++ b/operator_service/run.py
@@ -24,6 +24,8 @@ def version():
     info['software'] = Metadata.TITLE
     info['version'] = get_version()
     info['address'] = os.getenv('OPERATOR_ADDRESS',None)
+    info['algoTimeLimit'] = os.getenv('ALGO_POD_TIMEOUT',None)
+    info['storageExpiry'] = os.getenv('STORAGE_EXPIRY',None)
     return jsonify(info)
 
 

--- a/operator_service/utils.py
+++ b/operator_service/utils.py
@@ -4,6 +4,7 @@ import uuid
 import logging
 import mimetypes
 from cgi import parse_header
+from os import getenv
 
 from kubernetes.client.rest import ApiException
 from ocean_keeper import Keeper
@@ -121,7 +122,14 @@ def build_download_response(request, requests_session, url, content_type=None):
         if is_range_request:
             download_request_headers = {"Range": request.headers.get("range")}
             download_response_headers = download_request_headers
-
+        # IPFS utils
+        ipfs_x_api_key = getenv('X-API-KEY',None)
+        if ipfs_x_api_key:
+            download_request_headers['X-API-KEY'] = ipfs_x_api_key
+        ipfs_client_id = getenv('CLIENT-ID',None)
+        if ipfs_client_id:
+            download_request_headers['CLIENT-ID'] = ipfs_client_id
+             
         response = requests_session.get(
             url, headers=download_request_headers, stream=True, timeout=3
         )

--- a/operator_service/utils.py
+++ b/operator_service/utils.py
@@ -2,13 +2,18 @@ import json
 import os
 import uuid
 import logging
+import mimetypes
+from cgi import parse_header
 
 from kubernetes.client.rest import ApiException
 from ocean_keeper import Keeper
+from flask import Response, request
 
 from operator_service.exceptions import InvalidSignatureError
 
-logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(asctime)s %(message)s')
+logger = logging.getLogger('operator-service')
+logger.setLevel(logging.DEBUG)
 
 
 def generate_new_id():
@@ -106,3 +111,60 @@ def get_namespace_configs():
     resources = dict()
     resources['namespace'] = os.environ.get('DEFAULT_NAMESPACE', "ocean-compute")
     return resources
+
+def build_download_response(request, requests_session, url, content_type=None):
+    try:
+        download_request_headers = {}
+        download_response_headers = {}
+        is_range_request = bool(request.range)
+
+        if is_range_request:
+            download_request_headers = {"Range": request.headers.get("range")}
+            download_response_headers = download_request_headers
+
+        response = requests_session.get(
+            url, headers=download_request_headers, stream=True, timeout=3
+        )
+
+        if not is_range_request:
+            filename = url.split("/")[-1]
+
+            content_disposition_header = response.headers.get("content-disposition")
+            if content_disposition_header:
+                _, content_disposition_params = parse_header(content_disposition_header)
+                content_filename = content_disposition_params.get("filename")
+                if content_filename:
+                    filename = content_filename
+
+            content_type_header = response.headers.get("content-type")
+            if content_type_header:
+                content_type = content_type_header
+
+            file_ext = os.path.splitext(filename)[1]
+            if file_ext and not content_type:
+                content_type = mimetypes.guess_type(filename)[0]
+            elif not file_ext and content_type:
+                # add an extension to filename based on the content_type
+                extension = mimetypes.guess_extension(content_type)
+                if extension:
+                    filename = filename + extension
+
+            download_response_headers = {
+                "Content-Disposition": f"attachment;filename={filename}",
+                "Access-Control-Expose-Headers": "Content-Disposition",
+            }
+
+        def _generate(_response):
+            for chunk in _response.iter_content(chunk_size=4096):
+                if chunk:
+                    yield chunk
+
+        return Response(
+            _generate(response),
+            response.status_code,
+            headers=download_response_headers,
+            content_type=content_type,
+        )
+    except Exception as e:
+        logger.error(f"Error preparing file download response: {str(e)}")
+        raise

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/oceanprotocol/operator-service',
-    version='1.0.0',
+    version='1.0.1',
     zip_safe=False,
 )


### PR DESCRIPTION
Closes #30

Changes proposed in this PR:

- GET /compute    (get job results) hides the urls:
```json
[
  {
    "agreementId": "0x111111",
    "algoDID": "did:op:87bdaabb33354d2eb014af5091c604fb4b0f67dc6cca4d18a96547bffdc27bcf",
    "dateCreated": 1629281470.08931,
    "dateFinished": 1629281491.05138,
    "inputDID": [
      "did:op:1384941e6f0b46299b6e515723df3d8e8e5d1fb175554467a1cb7bc613f5c72e"
    ],
    "jobId": "6951125396154f2da719f097ae758bb5",
    "owner": "0xC41808BBef371AD5CFc76466dDF9dEe228d2BdAA",
    "removed": 0,
    "results": [
      {
        "filename": "output.log",
        "filesize": 85,
        "type": "output"
      },
      {
        "filename": "algorithm.log",
        "filesize": 127,
        "type": "algorithmLog"
      }
    ],
    "status": 70,
    "statusText": "Job finished",
    "stopreq": 0
  }
]
```

New endpoint:   GET /getResult , which retrieves an output from a job (index based)
```
parameters:
      - name: index
        in: query
        description: output index
        type: number
      - name: job_id
        in: query
        description: Id of the job.
        type: string
      - name: providerSignature
        in: query
        description: providerSignature
        type: string
      - name: consumerSignature
        in: query
        description: consumerSignature
        type: string
      - name: signatureText
        in: query
        description: signatureText
        type: string
    responses:
      200:
        description: File content
      400:
        description: Error
      404:
        description: Not found
    """

consumer & provider must sign the same text in order to prove that they have access