### PR TITLE
Fix non serializable compute post response

### DIFF
--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -180,6 +180,9 @@ def start_compute_job():
     logger.debug(f'Got body: {body}')
     create_sql_job(agreement_id, str(job_id), owner,body,environment, provider_address)
     status_list = get_sql_status(agreement_id, str(job_id), owner)
+    # Convert every value from the list of dicts to a string
+    status_list = [{k: str(v) for k, v in d.items()} for d in status_list]
+    
     return Response(json.dumps(status_list), 200, headers=standard_headers)
 
 


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

Fixes this error:
```
2022-03-03 15:19:05,526 Exception on /api/v1/operator/compute [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/operator-service/operator_service/routes.py", line 183, in start_compute_job
    return Response(json.dumps(status_list), 200, headers=standard_headers)
  File "/usr/local/lib/python3.6/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'Decimal' is not JSON serializable
```

Changes proposed in this PR:

-  Convert all keys in compute response to strings