### PR TITLE
Convert all get_sql_status values to string in compute get endpoint

### DIFF
--- a/operator_service/data_store.py
+++ b/operator_service/data_store.py
@@ -166,8 +166,8 @@ def get_sql_environments(logger):
         return result
     for row in rows:
         temprow = json.loads(row[1])
-        temprow['lastSeen'] = str(row[2])
-        temprow['id'] = row[0]
+        temprow["lastSeen"] = str(row[2])
+        temprow["id"] = row[0]
         result.append(temprow)
     return result
 

--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -208,7 +208,7 @@ def start_compute_job():
     status_list = get_sql_status(agreement_id, str(job_id), owner)
     # Convert every value from the list of dicts to a string
     status_list = [{k: str(v) for k, v in d.items()} for d in status_list]
-    
+
     return Response(json.dumps(status_list), 200, headers=standard_headers)
 
 

--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -396,6 +396,8 @@ def get_compute_job_status():
             return Response(json.dumps({"error": msg}), 400, headers=standard_headers)
         logger.debug(f"Got status request for {agreement_id}, {job_id}, {owner}")
         api_response = get_sql_status(agreement_id, job_id, owner)
+        api_response = [{k: str(v) for k, v in d.items()} for d in api_response]
+
         return Response(json.dumps(api_response), 200, headers=standard_headers)
 
     except ApiException as e:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,7 +6,7 @@ import pytest
 import operator_service.routes
 from operator_service.run import app
 
-FAKE_UUID = 'fake-uuid'
+FAKE_UUID = "fake-uuid"
 
 
 @pytest.fixture
@@ -24,10 +24,20 @@ def setup_mocks(monkeypatch):
     def mock_uuid():
         return FAKE_UUID
 
-    monkeypatch.setattr(operator_service.routes, 'generate_new_id', mock_uuid)
-    monkeypatch.setattr(operator_service.routes, 'KubeAPI', KubeAPIMock)
-    monkeypatch.setattr(operator_service.routes, 'create_sql_job', SQLMock.mock_create_sql_job)
-    monkeypatch.setattr(operator_service.routes, 'get_sql_jobs', SQLMock.mock_get_sql_jobs)
-    monkeypatch.setattr(operator_service.routes, 'stop_sql_job', SQLMock.mock_stop_sql_job)
-    monkeypatch.setattr(operator_service.routes, 'remove_sql_job', SQLMock.mock_remove_sql_job)
-    monkeypatch.setattr(operator_service.routes, 'get_sql_status', SQLMock.mock_get_sql_status)
+    monkeypatch.setattr(operator_service.routes, "generate_new_id", mock_uuid)
+    monkeypatch.setattr(operator_service.routes, "KubeAPI", KubeAPIMock)
+    monkeypatch.setattr(
+        operator_service.routes, "create_sql_job", SQLMock.mock_create_sql_job
+    )
+    monkeypatch.setattr(
+        operator_service.routes, "get_sql_jobs", SQLMock.mock_get_sql_jobs
+    )
+    monkeypatch.setattr(
+        operator_service.routes, "stop_sql_job", SQLMock.mock_stop_sql_job
+    )
+    monkeypatch.setattr(
+        operator_service.routes, "remove_sql_job", SQLMock.mock_remove_sql_job
+    )
+    monkeypatch.setattr(
+        operator_service.routes, "get_sql_status", SQLMock.mock_get_sql_status
+    )

--- a/test/kube_mock.py
+++ b/test/kube_mock.py
@@ -23,13 +23,19 @@ class KubeAPIMock:
         pass
 
     def create_namespaced_custom_object(self, body):
-        processed_workflow = deepcopy(VALID_COMPUTE_BODY['workflow'])
-        stage_compute = processed_workflow['stages'][0]['compute']
-        stage_compute['resources'] = get_compute_resources()
+        processed_workflow = deepcopy(VALID_COMPUTE_BODY["workflow"])
+        stage_compute = processed_workflow["stages"][0]["compute"]
+        stage_compute["resources"] = get_compute_resources()
         if KubeAPIMock.expected_maxtime:
-            stage_compute['maxtime'] = KubeAPIMock.expected_maxtime
+            stage_compute["maxtime"] = KubeAPIMock.expected_maxtime
         config = Config()
-        correct_body = create_compute_job(processed_workflow, FAKE_UUID, config.group, config.version, config.namespace)
+        correct_body = create_compute_job(
+            processed_workflow,
+            FAKE_UUID,
+            config.group,
+            config.version,
+            config.namespace,
+        )
         assert body == correct_body
 
     def delete_namespaced_custom_object(self, name, body, **_):

--- a/test/operator_payloads.py
+++ b/test/operator_payloads.py
@@ -1,67 +1,61 @@
 from copy import deepcopy
 
 VALID_COMPUTE_BODY = {
-    'agreementId': '0x0',
-    'owner': '0xC41808BBef371AD5CFc76466dDF9dEe228d2BdAA',
-    'providerSignature': 'sig',
-    'workflow': {
-        'stages': [
+    "agreementId": "0x0",
+    "owner": "0xC41808BBef371AD5CFc76466dDF9dEe228d2BdAA",
+    "providerSignature": "sig",
+    "workflow": {
+        "stages": [
             {
-                'algorithm': {
-                    'container': {
-                        'entrypoint': 'node $ALGO',
-                        'image': 'node',
-                        'tag': '10'
+                "algorithm": {
+                    "container": {
+                        "entrypoint": "node $ALGO",
+                        "image": "node",
+                        "tag": "10",
                     },
-                    'id': 'did:op:87bdaabb33354d2eb014af5091c604fb4b0f67dc6cca4d18a96547bffdc27bcf',
-                    'rawcode': "console.log('this is a test')",
-                    'url': 'https://raw.githubusercontent.com/oceanprotocol/test-algorithm/master/javascript/algo.js'
+                    "id": "did:op:87bdaabb33354d2eb014af5091c604fb4b0f67dc6cca4d18a96547bffdc27bcf",
+                    "rawcode": "console.log('this is a test')",
+                    "url": "https://raw.githubusercontent.com/oceanprotocol/test-algorithm/master/javascript/algo.js",
                 },
-                'compute': {
-                    'Instances': 1,
-                    'maxtime': 3600,
-                    'namespace': 'withgpu'
-                },
-                'index': 0,
-                'input': [
+                "compute": {"Instances": 1, "maxtime": 3600, "namespace": "withgpu"},
+                "index": 0,
+                "input": [
                     {
-                        'id': 'did:op:87bdaabb33354d2eb014af5091c604fb4b0f67dc6cca4d18a96547bffdc27bcf',
-                        'index': 0,
-                        'url': [
-                            'https://data.ok.gov/sites/default/files/unspsc%20codes_3.csv'
-                        ]
+                        "id": "did:op:87bdaabb33354d2eb014af5091c604fb4b0f67dc6cca4d18a96547bffdc27bcf",
+                        "index": 0,
+                        "url": [
+                            "https://data.ok.gov/sites/default/files/unspsc%20codes_3.csv"
+                        ],
                     },
                 ],
-                'output': {
-                    'brizoAddress': '0x4aaab179035dc57b35e2ce066919048686f82972',
-                    'brizoUri': 'https://brizo.marketplace.dev-ocean.com',
-                    'metadata': {
-                        'name': 'Workflow output'
-                    },
-                    'metadataUri': 'https://aquarius.marketplace.dev-ocean.com',
-                    'nodeUri': 'https://nile.dev-ocean.com',
-                    'owner': '0xC41808BBef371AD5CFc76466dDF9dEe228d2BdAA',
-                    'publishAlgorithmLog': True,
-                    'publishOutput': True,
-                    'secretStoreUri': 'https://secret-store.nile.dev-ocean.com',
-                    'whitelist': [
-                        '0x00Bd138aBD70e2F00903268F3Db08f2D25677C9e',
-                        '0xACBd138aBD70e2F00903268F3Db08f2D25677C9e'
-                    ]
-                }
+                "output": {
+                    "brizoAddress": "0x4aaab179035dc57b35e2ce066919048686f82972",
+                    "brizoUri": "https://brizo.marketplace.dev-ocean.com",
+                    "metadata": {"name": "Workflow output"},
+                    "metadataUri": "https://aquarius.marketplace.dev-ocean.com",
+                    "nodeUri": "https://nile.dev-ocean.com",
+                    "owner": "0xC41808BBef371AD5CFc76466dDF9dEe228d2BdAA",
+                    "publishAlgorithmLog": True,
+                    "publishOutput": True,
+                    "secretStoreUri": "https://secret-store.nile.dev-ocean.com",
+                    "whitelist": [
+                        "0x00Bd138aBD70e2F00903268F3Db08f2D25677C9e",
+                        "0xACBd138aBD70e2F00903268F3Db08f2D25677C9e",
+                    ],
+                },
             }
         ],
-    }
+    },
 }
 
 NO_WORKFLOW_COMPUTE_BODY = deepcopy(VALID_COMPUTE_BODY)
-NO_WORKFLOW_COMPUTE_BODY['workflow'] = {}
+NO_WORKFLOW_COMPUTE_BODY["workflow"] = {}
 
 NO_STAGES_COMPUTE_BODY = deepcopy(VALID_COMPUTE_BODY)
-NO_STAGES_COMPUTE_BODY['workflow']['stages'] = []
+NO_STAGES_COMPUTE_BODY["workflow"]["stages"] = []
 
 INVALID_STAGE_COMPUTE_BODY = deepcopy(VALID_COMPUTE_BODY)
-del INVALID_STAGE_COMPUTE_BODY['workflow']['stages'][0]['algorithm']
+del INVALID_STAGE_COMPUTE_BODY["workflow"]["stages"][0]["algorithm"]
 
 VALID_COMPUTE_BODY_WITH_NO_MAXTIME = deepcopy(VALID_COMPUTE_BODY)
-del VALID_COMPUTE_BODY_WITH_NO_MAXTIME['workflow']['stages'][0]['compute']['maxtime']
+del VALID_COMPUTE_BODY_WITH_NO_MAXTIME["workflow"]["stages"][0]["compute"]["maxtime"]

--- a/test/sql_mock.py
+++ b/test/sql_mock.py
@@ -1,5 +1,5 @@
-MOCK_JOB_STATUS = {'value': 'test'}
-MOCK_JOBS_LIST = ['job1', 'job2']
+MOCK_JOB_STATUS = {"value": "test"}
+MOCK_JOBS_LIST = ["job1", "job2"]
 
 
 class SQLMock:

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -1,4 +1,3 @@
-
 def test_init_pgsqlexecution():
     return
 

--- a/test/test_operator.py
+++ b/test/test_operator.py
@@ -4,20 +4,26 @@ from .conftest import FAKE_UUID
 from .kube_mock import KubeAPIMock
 from .sql_mock import SQLMock, MOCK_JOB_STATUS
 
-COMPUTE_URL = f'{BaseURLs.BASE_OPERATOR_URL}/compute'
+COMPUTE_URL = f"{BaseURLs.BASE_OPERATOR_URL}/compute"
 
 
 def test_operator(client):
-    response = client.get('/')
-    assert response.json['software'] == Metadata.TITLE
+    response = client.get("/")
+    assert response.json["software"] == Metadata.TITLE
 
 
 def test_start_compute_job(client, monkeypatch):
-    monkeypatch.setattr(SQLMock, 'expected_agreement_id', payloads.VALID_COMPUTE_BODY['agreementId'])
-    monkeypatch.setattr(SQLMock, 'expected_job_id', FAKE_UUID)
-    monkeypatch.setattr(SQLMock, 'expected_owner', payloads.VALID_COMPUTE_BODY['owner'])
+    monkeypatch.setattr(
+        SQLMock, "expected_agreement_id", payloads.VALID_COMPUTE_BODY["agreementId"]
+    )
+    monkeypatch.setattr(SQLMock, "expected_job_id", FAKE_UUID)
+    monkeypatch.setattr(SQLMock, "expected_owner", payloads.VALID_COMPUTE_BODY["owner"])
 
-    monkeypatch.setattr(KubeAPIMock, 'expected_maxtime', payloads.VALID_COMPUTE_BODY['workflow']['stages'][0]['compute']['maxtime'])
+    monkeypatch.setattr(
+        KubeAPIMock,
+        "expected_maxtime",
+        payloads.VALID_COMPUTE_BODY["workflow"]["stages"][0]["compute"]["maxtime"],
+    )
 
     response = client.post(COMPUTE_URL, json=payloads.VALID_COMPUTE_BODY)
     assert response.status_code == 200
@@ -35,36 +41,40 @@ def test_start_compute_job(client, monkeypatch):
     response = client.post(COMPUTE_URL, json=payloads.INVALID_STAGE_COMPUTE_BODY)
     assert response.status_code == 400
 
-    monkeypatch.setenv('ALGO_POD_TIMEOUT', str(1200))
-    monkeypatch.setattr(KubeAPIMock, 'expected_maxtime', 1200)
+    monkeypatch.setenv("ALGO_POD_TIMEOUT", str(1200))
+    monkeypatch.setattr(KubeAPIMock, "expected_maxtime", 1200)
 
     response = client.post(COMPUTE_URL, json=payloads.VALID_COMPUTE_BODY)
     assert response.status_code == 200
     assert response.json == MOCK_JOB_STATUS
 
-    response = client.post(COMPUTE_URL, json=payloads.VALID_COMPUTE_BODY_WITH_NO_MAXTIME)
+    response = client.post(
+        COMPUTE_URL, json=payloads.VALID_COMPUTE_BODY_WITH_NO_MAXTIME
+    )
     assert response.status_code == 200
     assert response.json == MOCK_JOB_STATUS
 
 
 def test_stop_compute_job(client, monkeypatch):
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_agreement_id', 'fake-agreement-id')
-        response = client.put(COMPUTE_URL, json={'agreementId': SQLMock.expected_agreement_id})
+        m.setattr(SQLMock, "expected_agreement_id", "fake-agreement-id")
+        response = client.put(
+            COMPUTE_URL, json={"agreementId": SQLMock.expected_agreement_id}
+        )
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
         SQLMock.assert_all_jobs_stopped_and_reset()
 
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_job_id', 'fake-job-id')
-        response = client.put(COMPUTE_URL, json={'jobId': SQLMock.expected_job_id})
+        m.setattr(SQLMock, "expected_job_id", "fake-job-id")
+        response = client.put(COMPUTE_URL, json={"jobId": SQLMock.expected_job_id})
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
         SQLMock.assert_all_jobs_stopped_and_reset()
 
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_owner', 'fake-owner')
-        response = client.put(COMPUTE_URL, json={'owner': SQLMock.expected_owner})
+        m.setattr(SQLMock, "expected_owner", "fake-owner")
+        response = client.put(COMPUTE_URL, json={"owner": SQLMock.expected_owner})
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
         SQLMock.assert_all_jobs_stopped_and_reset()
@@ -75,24 +85,26 @@ def test_stop_compute_job(client, monkeypatch):
 
 def test_delete_compute_job(client, monkeypatch):
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_agreement_id', 'fake-agreement-id')
-        response = client.delete(COMPUTE_URL, json={'agreementId': SQLMock.expected_agreement_id})
+        m.setattr(SQLMock, "expected_agreement_id", "fake-agreement-id")
+        response = client.delete(
+            COMPUTE_URL, json={"agreementId": SQLMock.expected_agreement_id}
+        )
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
         SQLMock.assert_all_jobs_removed_and_reset()
         KubeAPIMock.assert_all_objects_removed_and_reset()
 
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_job_id', 'fake-job-id')
-        response = client.delete(COMPUTE_URL, json={'jobId': SQLMock.expected_job_id})
+        m.setattr(SQLMock, "expected_job_id", "fake-job-id")
+        response = client.delete(COMPUTE_URL, json={"jobId": SQLMock.expected_job_id})
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
         SQLMock.assert_all_jobs_removed_and_reset()
         KubeAPIMock.assert_all_objects_removed_and_reset()
 
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_owner', 'fake-owner')
-        response = client.delete(COMPUTE_URL, json={'owner': SQLMock.expected_owner})
+        m.setattr(SQLMock, "expected_owner", "fake-owner")
+        response = client.delete(COMPUTE_URL, json={"owner": SQLMock.expected_owner})
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
         SQLMock.assert_all_jobs_removed_and_reset()
@@ -104,20 +116,22 @@ def test_delete_compute_job(client, monkeypatch):
 
 def test_get_compute_job_status(client, monkeypatch):
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_agreement_id', 'fake-agreement-id')
-        response = client.get(COMPUTE_URL, json={'agreementId': SQLMock.expected_agreement_id})
+        m.setattr(SQLMock, "expected_agreement_id", "fake-agreement-id")
+        response = client.get(
+            COMPUTE_URL, json={"agreementId": SQLMock.expected_agreement_id}
+        )
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
 
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_job_id', 'fake-job-id')
-        response = client.get(COMPUTE_URL, json={'jobId': SQLMock.expected_job_id})
+        m.setattr(SQLMock, "expected_job_id", "fake-job-id")
+        response = client.get(COMPUTE_URL, json={"jobId": SQLMock.expected_job_id})
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
 
     with monkeypatch.context() as m:
-        m.setattr(SQLMock, 'expected_owner', 'fake-owner')
-        response = client.get(COMPUTE_URL, json={'owner': SQLMock.expected_owner})
+        m.setattr(SQLMock, "expected_owner", "fake-owner")
+        response = client.get(COMPUTE_URL, json={"owner": SQLMock.expected_owner})
         assert response.status_code == 200
         assert response.json == MOCK_JOB_STATUS
 


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

Fixes #40  .

Changes proposed in this PR:

- Convert all get_sql_status values to string in compute get endpoint as we did for the post endoint https://github.com/oceanprotocol/operator-service/commit/770f169cae4b64b979791da04563cb73ad9fb0e4
- Fix black problems