### PR TITLE
Fix non serializable responses by converting Decimals to floats

### DIFF
--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import os
 from os import path
 import logging
@@ -23,6 +24,7 @@ from operator_service.kubernetes_api import KubeAPI
 from operator_service.utils import (
     create_compute_job,
     check_required_attributes,
+    decimals_to_float,
     generate_new_id,
     process_signature_validation,
     get_compute_resources,
@@ -206,10 +208,10 @@ def start_compute_job():
         agreement_id, str(job_id), owner, body, environment, provider_address
     )
     status_list = get_sql_status(agreement_id, str(job_id), owner)
-    # Convert every value from the list of dicts to a string
-    status_list = [{k: str(v) for k, v in d.items()} for d in status_list]
 
-    return Response(json.dumps(status_list), 200, headers=standard_headers)
+    return Response(
+        json.dumps(decimals_to_float(status_list)), 200, headers=standard_headers
+    )
 
 
 @services.route("/compute", methods=["PUT"])
@@ -396,9 +398,10 @@ def get_compute_job_status():
             return Response(json.dumps({"error": msg}), 400, headers=standard_headers)
         logger.debug(f"Got status request for {agreement_id}, {job_id}, {owner}")
         api_response = get_sql_status(agreement_id, job_id, owner)
-        api_response = [{k: str(v) for k, v in d.items()} for d in api_response]
 
-        return Response(json.dumps(api_response), 200, headers=standard_headers)
+        return Response(
+            json.dumps(decimals_to_float(api_response)), 200, headers=standard_headers
+        )
 
     except ApiException as e:
         msg = f"Error getting the status: {e}"

--- a/operator_service/routes.py
+++ b/operator_service/routes.py
@@ -1,4 +1,3 @@
-from decimal import Decimal
 import os
 from os import path
 import logging

--- a/operator_service/utils.py
+++ b/operator_service/utils.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import json
 import os
 import uuid
@@ -180,3 +181,19 @@ def build_download_response(request, requests_session, url, content_type=None):
     except Exception as e:
         logger.error(f"Error preparing file download response: {str(e)}")
         raise
+
+
+def decimals_to_float(d):
+    """
+    Recursively convert Decimal to float
+    in: dict | list | tuple | set | str | int | float | None
+    out: dict | list | tuple | set | str | int | float | None
+    """
+    if isinstance(d, Decimal):
+        return float(d)
+    elif isinstance(d, dict):
+        return {decimals_to_float(k): decimals_to_float(v) for k, v in d.items()}
+    elif isinstance(d, list):
+        return [decimals_to_float(element) for element in d]
+    else:
+        return d


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

Changes proposed in this PR:

- Instead of converting all values to string we only convert `Decimal `s to `float`