### PR TITLE
add test infrastructure

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,9 +82,12 @@ jobs:
       - name: Wait for registry
         run: |
           for i in $(seq 1 250); do
-              RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
-              [ "$RUNNING" == "true" ] && break
-          done
+            sleep 5
+            RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
+            if [ "$RUNNING" == "true" ]; then
+              break
+            fi
+            done
       - name:  Push local docker images
         run: |
           docker push 172.15.0.11:5000/operator-service:test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -84,6 +84,9 @@ jobs:
           for i in $(seq 1 250); do
             sleep 5
             RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
+            if [ $? -eq 1 ]; then
+                echo "3" # "Registry not started."
+            fi
             if [ "$RUNNING" == "true" ]; then
               break
             fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,65 +16,60 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set ADDRESS_FILE
-        run: echo "ADDRESS_FILE=${HOME}/.ocean/ocean-contracts/artifacts/address.json" >> $GITHUB_ENV
-      - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_PASSWORD && env.DOCKERHUB_USERNAME }}
-        run: |
-          echo "Login to Docker Hub";echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build local Docker for operator-service
-        run: docker build -t '172.15.0.11:5000/operator-service:test' .
-      
-      
-      - name: Checkout Operator-Engine
-        uses: actions/checkout@v2
-        with:
-          repository: 'oceanprotocol/operator-engine'
-          path: 'operator-engine'
-          ref: v4main
-      - name: Build local Docker for operator-engine
-        working-directory: ${{ github.workspace }}/operator-engine
-        run: docker build -t '172.15.0.11:5000/operator-engine:test' .
-      
-      
-      - name: Checkout Pod-configuration
-        uses: actions/checkout@v2
-        with:
-          repository: 'oceanprotocol/pod-configuration'
-          path: 'pod-configuration'
-          ref: v4main
-      - name: Build local Docker for pod-configuration
-        working-directory: ${{ github.workspace }}/pod-configuration
-        run: docker build -t '172.15.0.11:5000/pod-configuration:test' .
-      
-      
-      - name: Checkout pod-publishing
-        uses: actions/checkout@v2
-        with:
-          repository: 'oceanprotocol/pod-publishing'
-          path: 'pod-publishing'
-          ref: v4main
-      - name: Build local Docker for pod-publishing
-        working-directory: ${{ github.workspace }}/pod-publishing
-        run: docker build -t '172.15.0.11:5000/pod-publishing:test' .
       - name: Checkout Barge
         uses: actions/checkout@v2
         with:
           repository: 'oceanprotocol/barge'
           path: 'barge'
           ref: v4
-      
+      - name: Checkout Operator-Engine
+        uses: actions/checkout@v2
+        with:
+          repository: 'oceanprotocol/operator-engine'
+          path: 'operator-engine'
+          ref: v4main
+      - name: Checkout Pod-configuration
+        uses: actions/checkout@v2
+        with:
+          repository: 'oceanprotocol/pod-configuration'
+          path: 'pod-configuration'
+          ref: v4main
+      - name: Checkout pod-publishing
+        uses: actions/checkout@v2
+        with:
+          repository: 'oceanprotocol/pod-publishing'
+          path: 'pod-publishing'
+          ref: v4main
+
       - name: Update local docker settings 
         working-directory: ${{ github.workspace }}/barge
         run: |
+          ls -l ./
           sudo mkdir /etc/docker/certs.d
           sudo mkdir /etc/docker/certs.d/172.15.0.11:5000
           sudo cp ./certs/registry.crt /etc/docker/certs.d/172.15.0.11:5000/ca.crt
 
+      - name: Build local Docker for operator-service
+        run: docker build -t '172.15.0.11:5000/operator-service:test' .
+      
+      
+      - name: Build local Docker for operator-engine
+        working-directory: ${{ github.workspace }}/operator-engine
+        run: docker build -t '172.15.0.11:5000/operator-engine:test' .
+      
+      
+      - name: Build local Docker for pod-configuration
+        working-directory: ${{ github.workspace }}/pod-configuration
+        run: docker build -t '172.15.0.11:5000/pod-configuration:test' .
+      
+      
+      - name: Build local Docker for pod-publishing
+        working-directory: ${{ github.workspace }}/pod-publishing
+        run: docker build -t '172.15.0.11:5000/pod-publishing:test' .
+      
+      - name: Set ADDRESS_FILE
+        run: echo "ADDRESS_FILE=${HOME}/.ocean/ocean-contracts/artifacts/address.json" >> $GITHUB_ENV
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,7 @@ jobs:
           ls -l ./
           sudo mkdir /etc/docker/certs.d
           sudo mkdir /etc/docker/certs.d/172.15.0.11:5000
-          sudo cp ./certs/registry.crt /etc/docker/certs.d/172.15.0.11:5000/ca.crt
+          sudo cp ./certs/registry/registry.crt /etc/docker/certs.d/172.15.0.11:5000/ca.crt
 
       - name: Build local Docker for operator-service
         run: docker build -t '172.15.0.11:5000/operator-service:test' .

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,13 +16,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
       - name: Set ADDRESS_FILE
         run: echo "ADDRESS_FILE=${HOME}/.ocean/ocean-contracts/artifacts/address.json" >> $GITHUB_ENV
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_PASSWORD && env.DOCKERHUB_USERNAME }}
+        run: |
+          echo "Login to Docker Hub";echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Build local Docker for operator-service
         run: docker build -t '172.15.0.11:5000/operator-service:test' .
+      
+      
       - name: Checkout Operator-Engine
         uses: actions/checkout@v2
         with:
@@ -32,6 +39,8 @@ jobs:
       - name: Build local Docker for operator-engine
         working-directory: ${{ github.workspace }}/operator-engine
         run: docker build -t '172.15.0.11:5000/operator-engine:test' .
+      
+      
       - name: Checkout Pod-configuration
         uses: actions/checkout@v2
         with:
@@ -41,6 +50,8 @@ jobs:
       - name: Build local Docker for pod-configuration
         working-directory: ${{ github.workspace }}/pod-configuration
         run: docker build -t '172.15.0.11:5000/pod-configuration:test' .
+      
+      
       - name: Checkout pod-publishing
         uses: actions/checkout@v2
         with:
@@ -56,19 +67,13 @@ jobs:
           repository: 'oceanprotocol/barge'
           path: 'barge'
           ref: v4
+      
       - name: Update local docker settings 
         working-directory: ${{ github.workspace }}/barge
         run: |
-          mkdir /etc/docker/certs.d
-          mkdir /etc/docker/certs.d/172.15.0.11:5000
-          cp ./certs/registry.crt /etc/docker/certs.d/172.15.0.11:5000/ca.crt
-      - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_PASSWORD && env.DOCKERHUB_USERNAME }}
-        run: |
-          echo "Login to Docker Hub";echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          sudo mkdir /etc/docker/certs.d
+          sudo mkdir /etc/docker/certs.d/172.15.0.11:5000
+          sudo cp ./certs/registry.crt /etc/docker/certs.d/172.15.0.11:5000/ca.crt
 
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -106,7 +106,7 @@ jobs:
           
 
       - name: integration
-        run: wget http://172.15.0.13:31000/
+        run: curl http://172.15.0.13:31000/
       - name:  docker logs
         run: docker logs ocean_aquarius_1 && docker logs ocean_provider_1 && docker logs ocean_provider2_1 && docker logs ocean_computetodata_1
         if: ${{ failure() }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,7 +83,9 @@ jobs:
         run:
           for i in $(seq 1 250); do
             RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
-            if [ "$RUNNING" == "true" ]; then break; fi
+            if [ "$RUNNING" == "true" ]; then
+              break
+            fi
             done
       - name:  Push local docker images
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,102 @@
+name: 'Integration'
+
+on:
+  push:
+    branches:
+      - v4main
+    tags:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test_integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Set ADDRESS_FILE
+        run: echo "ADDRESS_FILE=${HOME}/.ocean/ocean-contracts/artifacts/address.json" >> $GITHUB_ENV
+      - name: Build local Docker for operator-service
+        run: docker build -t '172.15.0.11:5000/operator-service:test' .
+      - name: Checkout Operator-Engine
+        uses: actions/checkout@v2
+        with:
+          repository: 'oceanprotocol/operator-engine'
+          path: 'operator-engine'
+          ref: v4main
+      - name: Build local Docker for operator-engine
+        working-directory: ${{ github.workspace }}/operator-engine
+        run: docker build -t '172.15.0.11:5000/operator-engine:test' .
+      - name: Checkout Pod-configuration
+        uses: actions/checkout@v2
+        with:
+          repository: 'oceanprotocol/pod-configuration'
+          path: 'pod-configuration'
+          ref: v4main
+      - name: Build local Docker for pod-configuration
+        working-directory: ${{ github.workspace }}/pod-configuration
+        run: docker build -t '172.15.0.11:5000/pod-configuration:test' .
+      - name: Checkout pod-publishing
+        uses: actions/checkout@v2
+        with:
+          repository: 'oceanprotocol/pod-publishing'
+          path: 'pod-publishing'
+          ref: v4main
+      - name: Build local Docker for pod-publishing
+        working-directory: ${{ github.workspace }}/pod-publishing
+        run: docker build -t '172.15.0.11:5000/pod-publishing:test' .
+      - name: Checkout Barge
+        uses: actions/checkout@v2
+        with:
+          repository: 'oceanprotocol/barge'
+          path: 'barge'
+          ref: v4
+      - name: Update local docker settings 
+        working-directory: ${{ github.workspace }}/barge
+        run: |
+          mkdir /etc/docker/certs.d
+          mkdir /etc/docker/certs.d/172.15.0.11:5000
+          cp ./certs/registry.crt /etc/docker/certs.d/172.15.0.11:5000/ca.crt
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_PASSWORD && env.DOCKERHUB_USERNAME }}
+        run: |
+          echo "Login to Docker Hub";echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Run Barge
+        working-directory: ${{ github.workspace }}/barge
+        run: |
+          bash -x start_ocean.sh --with-provider2 --no-dashboard --with-c2d 2>&1 > start_ocean.log &
+        env:
+          OPERATOR_SERVICE_VERSION: 172.15.0.11:5000/operator-service:test
+          OPERATOR_ENGINE_VERSION: 172.15.0.11:5000/operator-engine:test
+          POD_CONFIGURATION_VERSION: 172.15.0.11:5000/pod-configuration:test
+          POD_CONFIGURATION_VERSION: 172.15.0.11:5000/pod-publishing:test
+      - name:  Push local docker images
+        run: |
+          docker push 172.15.0.11:5000/operator-service:test
+          docker push  172.15.0.11:5000/operator-engine:test
+          docker push  172.15.0.11:5000/pod-configuration:test
+          docker push  172.15.0.11:5000/pod-publishing:test
+      - name: Wait for contracts deployment and C2D cluster to be ready
+        working-directory: ${{ github.workspace }}/barge
+        run: |
+          for i in $(seq 1 250); do
+            sleep 10
+            [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
+            done
+          
+
+      - name: integration
+        run: wget http://172.15.0.13:31000/
+      - name:  docker logs
+        run: docker logs ocean_aquarius_1 && docker logs ocean_provider_1 && docker logs ocean_provider2_1 && docker logs ocean_computetodata_1
+        if: ${{ failure() }}
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           for i in $(seq 1 250); do
             sleep 5
-            if [RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)] then
+            if [RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)]; then
               break
             fi
             done

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,6 +79,7 @@ jobs:
           OPERATOR_ENGINE_VERSION: 172.15.0.11:5000/operator-engine:test
           POD_CONFIGURATION_VERSION: 172.15.0.11:5000/pod-configuration:test
           POD_PUBLISHING_VERSION: 172.15.0.11:5000/pod-publishing:test
+          WAIT_FOR_C2DIMAGES: "yeah"
       - name: Wait for registry
         run: |
           for i in $(seq 1 250); do
@@ -91,9 +92,10 @@ jobs:
       - name:  Push local docker images
         run: |
           docker push 172.15.0.11:5000/operator-service:test
-          docker push  172.15.0.11:5000/operator-engine:test
-          docker push  172.15.0.11:5000/pod-configuration:test
-          docker push  172.15.0.11:5000/pod-publishing:test
+          docker push 172.15.0.11:5000/operator-engine:test
+          docker push 172.15.0.11:5000/pod-configuration:test
+          docker push 172.15.0.11:5000/pod-publishing:test
+          touch $HOME/.ocean/ocean-c2d/imagesready
       - name: Wait for contracts deployment and C2D cluster to be ready
         working-directory: ${{ github.workspace }}/barge
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           for i in $(seq 1 250); do
             sleep 5
-            if [RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)]; then
+            if [docker inspect --format="{{.State.Running}}" docker-registry]; then
               break
             fi
             done

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,11 +83,7 @@ jobs:
         run: |
           for i in $(seq 1 250); do
             sleep 5
-            RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
-            if [ $? -eq 1 ]; then
-                echo "3" # "Registry not started."
-            fi
-            if [ "$RUNNING" == "true" ]; then
+            if [RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)] then
               break
             fi
             done

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,6 +79,12 @@ jobs:
           OPERATOR_ENGINE_VERSION: 172.15.0.11:5000/operator-engine:test
           POD_CONFIGURATION_VERSION: 172.15.0.11:5000/pod-configuration:test
           POD_PUBLISHING_VERSION: 172.15.0.11:5000/pod-publishing:test
+      - name: Wait for registry
+        run:
+          for i in $(seq 1 250); do
+            RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
+            if [ "$RUNNING" == "true" ]; then break; fi
+            done
       - name:  Push local docker images
         run: |
           docker push 172.15.0.11:5000/operator-service:test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,6 +87,7 @@ jobs:
               break
             fi
             done
+            sleep 3
       - name:  Push local docker images
         run: |
           docker push 172.15.0.11:5000/operator-service:test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,7 +80,7 @@ jobs:
           POD_CONFIGURATION_VERSION: 172.15.0.11:5000/pod-configuration:test
           POD_PUBLISHING_VERSION: 172.15.0.11:5000/pod-publishing:test
       - name: Wait for registry
-        run:
+        run: |
           for i in $(seq 1 250); do
               RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
               [ "$RUNNING" == "true" ] && break

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           for i in $(seq 1 250); do
             sleep 5
-            if [docker inspect --format="{{.State.Running}}" docker-registry]; then
+            if docker inspect --format='{{.State.Running}}' docker-registry; then
               break
             fi
             done

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,11 +82,9 @@ jobs:
       - name: Wait for registry
         run:
           for i in $(seq 1 250); do
-            RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
-            if [ "$RUNNING" == "true" ]; then
-              break
-            fi
-            done
+              RUNNING=$(docker inspect --format="{{.State.Running}}" docker-registry)
+              [ "$RUNNING" == "true" ] && break
+          done
       - name:  Push local docker images
         run: |
           docker push 172.15.0.11:5000/operator-service:test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,7 +78,7 @@ jobs:
           OPERATOR_SERVICE_VERSION: 172.15.0.11:5000/operator-service:test
           OPERATOR_ENGINE_VERSION: 172.15.0.11:5000/operator-engine:test
           POD_CONFIGURATION_VERSION: 172.15.0.11:5000/pod-configuration:test
-          POD_CONFIGURATION_VERSION: 172.15.0.11:5000/pod-publishing:test
+          POD_PUBLISHING_VERSION: 172.15.0.11:5000/pod-publishing:test
       - name:  Push local docker images
         run: |
           docker push 172.15.0.11:5000/operator-service:test


### PR DESCRIPTION
Setup the infrastructure for upcoming integration tests.

- build docker images from op-service PR branch
- builds docker images for op-engine, pod-config, pod-publish
- pushes the c2d images to local registry
- starts barge with c2d using the local images