### PR TITLE
Update postgres-configmap.yaml

### DIFF
--- a/kubernetes/postgres-configmap.yaml
+++ b/kubernetes/postgres-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: postgres-config
+  namespace: ocean-operator
   labels:
     app: postgres
 data:


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- specify `ocean-operator` namespace in ConfigMap 
- should be created in the same namespace as `Postgresql` and `operator-service` deployments
